### PR TITLE
Update to support TypeScript 4.5 / Deno 1.17

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,6 +29,13 @@
             "problemMatcher": []
         },
         {
+            "label": "Run test setup",
+            "type": "shell",
+            "command": "deno",
+            "args": ["run", "--allow-write", "--allow-net", "--allow-env", "vertex/lib/test-setup.ts"],
+            "problemMatcher": []
+        },
+        {
             "label": "Destroy Neo4j Test Database",
             "type": "shell",
             "command": "docker-compose",

--- a/vertex/layer2/data-request.ts
+++ b/vertex/layer2/data-request.ts
@@ -60,13 +60,15 @@ export type AnyDataRequest<VNT extends BaseVNodeType> = BaseDataRequest<VNT, any
 
 /** A helper that mixins can use to update their state in a data request. */
 export type UpdateMixin<VNT extends BaseVNodeType, ThisRequest, CurrentMixin, NewMixin> = (
-    ThisRequest extends BaseDataRequest<VNT, infer requestedProperties, CurrentMixin & RequiredMixin & infer Other> ?
-        (
-            BaseDataRequest<VNT, requestedProperties, NewMixin & RequiredMixin & Other> extends infer X ? X : never
-            //                                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            // This "extends infer" seems like a no-op but prevents this type from becoming deeply recursive.
-            // Thanks to https://github.com/microsoft/TypeScript/issues/30188#issuecomment-478938437 for the tip
-        )
+    ThisRequest extends BaseDataRequest<VNT, infer requestedProperties, infer AllMixins> ?
+        AllMixins extends CurrentMixin & RequiredMixin & infer Other ?
+            (
+                BaseDataRequest<VNT, requestedProperties, NewMixin & RequiredMixin & Other> extends infer X ? X : never
+                //                                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                // This "extends infer" seems like a no-op but prevents this type from becoming deeply recursive.
+                // Thanks to https://github.com/microsoft/TypeScript/issues/30188#issuecomment-478938437 for the tip
+            )
+        : never
     : never
 );
 

--- a/vertex/layer3/data-request-mixins.ts
+++ b/vertex/layer3/data-request-mixins.ts
@@ -42,7 +42,7 @@ type VPTarget<VirtProp extends VirtualManyRelationshipProperty|VirtualOneRelatio
 /** Allow requesting virtual properties, optionally based on whether or not a flag is set */
 export type VirtualPropsMixin<
     VNT extends VNodeTypeWithVirtualProps,
-    includedVirtualProps extends RecursiveVirtualPropRequest<VNT>|unknown = unknown,
+    includedVirtualProps extends RecursiveVirtualPropRequest<VNT> = Record<never, never>,
 > = ({
     [propName in keyof VNT["virtualProperties"]]:
         VNT["virtualProperties"][propName] extends VirtualManyRelationshipProperty ?
@@ -137,7 +137,7 @@ type ProjectRelationshipProps<Rel extends RelationshipDeclaration|undefined> = (
 /** Allow requesting derived properties, optionally based on whether or not a flag is set */
 export type DerivedPropsMixin<
     VNT extends VNodeType,
-    includedDerivedProps extends DerivedPropRequest<VNT>|unknown = unknown,
+    includedDerivedProps extends DerivedPropRequest<VNT> = Record<never, never>,
 > = ({
     [propName in keyof VNT["derivedProperties"]]:
         // For each derived property, add a method for requesting that derived property:

--- a/vertex/lib/types/field.ts
+++ b/vertex/lib/types/field.ts
@@ -258,10 +258,10 @@ function makePropertyField<FT extends PropertyFieldType, Nullable extends boolea
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function _getFieldTypes<Nullable extends boolean>(nullable: Nullable) {
     return {
-        // Note: all of the code below should work just fine without th "as Nullable extends ?..." part.
+        // Note: all of the code below should work just fine without th "as unknown as Nullable extends ?..." part.
         // It is just used to give these types nicer names when field schemas are viewed in an IDE.
-        VNID: makePropertyField(FieldType.VNID, nullable, validateVNID) as Nullable extends true ? _NullableVNIDField : _VNIDField,
-        Int: makePropertyField(FieldType.Int, nullable, validateInteger) as Nullable extends true ? _NullableIntField : _IntField,
+        VNID: makePropertyField(FieldType.VNID, nullable, validateVNID) as unknown as Nullable extends true ? _NullableVNIDField : _VNIDField,
+        Int: makePropertyField(FieldType.Int, nullable, validateInteger) as unknown as Nullable extends true ? _NullableIntField : _IntField,
         /** A signed integer up to 64 bits. For larger than 64 bits, use a string type as Neo4j doesn't support it. */
         BigInt: makePropertyField(FieldType.BigInt, nullable, validateBigInt),
         Float: makePropertyField(FieldType.Float, nullable, validateFloat),
@@ -275,10 +275,10 @@ function _getFieldTypes<Nullable extends boolean>(nullable: Nullable) {
          * e.g. using https://deno.land/x/computed_types :
          *     myString: Field.String.Check(string.min(2).max(100))
          */
-        String: makePropertyField(FieldType.String, nullable, validateString, trimStringMaxLength(1_000)) as Nullable extends true ? _NullableStringField : _StringField,
+        String: makePropertyField(FieldType.String, nullable, validateString, trimStringMaxLength(1_000)) as unknown as Nullable extends true ? _NullableStringField : _StringField,
         /** A unicode-aware slug (cannot contain spaces/punctuation). Valid: "the-thing". Invalid: "foo_bar" or "foo bar" */
-        Slug: makePropertyField(FieldType.Slug, nullable, validateSlug, trimStringMaxLength(60)) as Nullable extends true ? _NullableSlugField : _SlugField,
-        Boolean: makePropertyField(FieldType.Boolean, nullable, validateBoolean) as Nullable extends true ? _NullableBooleanField : _BooleanField,
+        Slug: makePropertyField(FieldType.Slug, nullable, validateSlug, trimStringMaxLength(60)) as unknown as Nullable extends true ? _NullableSlugField : _SlugField,
+        Boolean: makePropertyField(FieldType.Boolean, nullable, validateBoolean) as unknown as Nullable extends true ? _NullableBooleanField : _BooleanField,
         /** A calendar date, i.e. a date without time information */
         Date: makePropertyField(FieldType.Date, nullable, validateVDate),
         DateTime: makePropertyField(FieldType.DateTime, nullable, validateDateTime),


### PR DESCRIPTION
https://deno.com/blog/v1.17#typescript-45

At first there was a TypeScript error `Excessive stack depth comparing types` with some similar `?` in the error message as seen in https://github.com/microsoft/TypeScript/issues/46989 :

```
error: TS2321 [ERROR]: Excessive stack depth comparing types
     'BaseDataRequest<VNT, requestedProperties, ? & RequiredMixin & Other>' and
     'BaseDataRequest<VNT, requestedProperties, ? & RequiredMixin & Other>'.
        const prevAction = await tx.pullOne(Action, a => a.description.revertedBy(ra => ra.id), {key: data.actionId});
                                                                                  ~~~~~~~~~~~
    at file:///Users/braden/Documents/Neolace/vertex-framework/vertex/layer4/action-generic.ts:40:83
```

After a long time, I figured out that wrapping some conditional types in an extra layer of `infer` would work around the issue.