### PR TITLE
Upgrade to Neo4j 4.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Neo4j graph database
   ################################################################
   neo4j:
-    image: neo4j:4.2
+    image: neo4j:4.3
     environment:
       # Set default password to "vertex"
       NEO4J_AUTH: neo4j/vertex

--- a/vertex/deps.ts
+++ b/vertex/deps.ts
@@ -1,4 +1,4 @@
-import neo4j, * as Neo4j from "https://raw.githubusercontent.com/technotes-org/neo4j-javascript-driver/4.3-deno/neo4j-driver-lite/src/index.ts";
+import neo4j, * as Neo4j from "https://raw.githubusercontent.com/bradenmacdonald/deno-neo4j-lite-client/main/mod.ts";
 export {
     neo4j,
     Neo4j,

--- a/vertex/lib/test-setup.ts
+++ b/vertex/lib/test-setup.ts
@@ -2,7 +2,7 @@ import { log } from "./log.ts"
 import { testGraph, createTestData } from "../test-project/index.ts";
 
 
-log.info("Seting up test environment");
+log.info("Setting up test environment");
 // Wipe out all existing Neo4j data
 await testGraph.reverseAllMigrations();
 // Apply pending migrations

--- a/vertex/vertex.test.ts
+++ b/vertex/vertex.test.ts
@@ -37,7 +37,7 @@ group("Vertex Core", () => {
             await assertThrowsAsync(
                 () => testGraph.read(tx => tx.run("RETURN tribble bibble")),
                 undefined,
-                "Invalid input 'b'",  // The 'b' at the start of "bibble" is where the parsing error occurs
+                "Invalid input 'bibble'",
             );
         });
     });


### PR DESCRIPTION
Bumping supported Neo4j version from 4.2 to 4.3.

I would prefer to use 4.4, which is an LTS release that [will be supported until Dec 2024](https://neo4j.com/developer/kb/neo4j-supported-versions/) - but it seems to be very unstable, or at least this framework's test suite seems to cause some type of corruption bug.

