### PR TITLE
Minor fixes

### DIFF
--- a/vertex/layer2/schema.ts
+++ b/vertex/layer2/schema.ts
@@ -61,7 +61,7 @@ export const migrations: Readonly<{[id: string]: Migration}> = Object.freeze({
                     CALL apoc.trigger.add("createSlugIdRelation","
                         UNWIND $createdNodes AS n
                         WITH n
-                        WHERE n:VNode AND EXISTS(n.slugId)
+                        WHERE n:VNode AND n.slugId IS NOT NULL
                         CREATE (:SlugId {slugId: n.slugId, timestamp: datetime()})-[:IDENTIFIES]->(n)
                     ", {phase:"before"})
                 `);

--- a/vertex/vertex-interface.ts
+++ b/vertex/vertex-interface.ts
@@ -32,10 +32,8 @@ export interface VertexCore {
 type dbWriteType = <T>(code: (tx: WrappedTransaction) => Promise<T>) => Promise<T>;
 
 export interface Migration {
-    // deno-lint-ignore no-explicit-any
-    forward: (dbWrite: dbWriteType) => Promise<any>;
-    // deno-lint-ignore no-explicit-any
-    backward: (dbWrite: dbWriteType) => Promise<any>;
+    forward: (tx: dbWriteType) => Promise<unknown>;
+    backward: (dbWrite: dbWriteType) => Promise<unknown>;
     dependsOn: string[];
 }
 

--- a/vertex/vertex.ts
+++ b/vertex/vertex.ts
@@ -289,8 +289,8 @@ export class Vertex implements VertexCore {
                 // Apply the migration
                 log.info(`Applying migration "${migrationId}"`);
                 await this._restrictedAllowWritesWithoutAction(async () => {
+                    await migration.forward(dbWrite);
                     await dbWrite(async tx => {
-                        await migration.forward(dbWrite);
                         await tx.run(`
                             CREATE (m:Migration {id: $migrationId})
                             WITH m as m2

--- a/vertex/vertex.ts
+++ b/vertex/vertex.ts
@@ -175,13 +175,13 @@ export class Vertex implements VertexCore {
     public async _restrictedAllowWritesWithoutAction<T>(someCode: () => Promise<T>): Promise<void> {
         try {
             if (await this.isTriggerInstalled("trackActionChanges")) {
-                await this._restrictedWrite(tx => tx.run(`CALL apoc.trigger.pause("trackActionChanges")`));
+                await this._restrictedWrite(tx => tx.run(`CALL apoc.trigger.pause("trackActionChanges") YIELD name`));  // Without "YIELD name" this returns the code of the whole trigger.
             }
             await someCode();
         } finally {
             // We must check again if the trigger is installed since someCode() may have changed it.
             if (await this.isTriggerInstalled("trackActionChanges")) {
-                await this._restrictedWrite(tx => tx.run(`CALL apoc.trigger.resume("trackActionChanges")`));
+                await this._restrictedWrite(tx => tx.run(`CALL apoc.trigger.resume("trackActionChanges") YIELD name`));  // Without "YIELD name" this returns the code of the whole trigger.
             }
         }
     }


### PR DESCRIPTION
A few minor fixes:
* Update to newer Cypher syntax (`IS NOT NULL` instead of `exists()`)
* Change typing of a return type to not require a lint exception
* When pausing/resuming a trigger, don't have neo4j send us the whole trigger code over the wire each time.
* Fix placement of code that made it look like migrations run in a transaction with the code that records completed migrations, which they don't