### PR TITLE
Use APOC Core (included with Neo4j) instead of downloading APOC Full

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,15 @@ services:
       # Set default password to "vertex"
       NEO4J_AUTH: neo4j/vertex
       # We need trigger functionality, which is part of "APOC" and must be enabled:
-      NEO4JLABS_PLUGINS: '["apoc"]'
+      # The following will enable "APOC Full", but it takes time to download and install.
+      # NEO4JLABS_PLUGINS: '["apoc"]'
+      # We only need APOC core, which is included in the image; we only have to change the plugins directory to enable it:
+      NEO4J_dbms_directories_plugins: /var/lib/neo4j/labs
+      NEO4J_dbms_security_procedures_unrestricted: apoc.*
+      # Enable trigger functionality:
       NEO4J_apoc_trigger_enabled: "true"
       # The following is needed for apoc.export.cypher.all, even though we're only exporting to memory, not disk.
-      apoc.export.file.enabled: "true"
+      NEO4J_apoc_export_file_enabled: "true"
     ports:
       - 7774:7474  # Browse on your host at http://localhost:7774/browser/?connectURL=neo4j://localhost:7777
       - 7777:7687  # Bolt

--- a/vertex/layer2/schema.ts
+++ b/vertex/layer2/schema.ts
@@ -70,7 +70,8 @@ export const migrations: Readonly<{[id: string]: Migration}> = Object.freeze({
                 //    If the SlugId already exists, update its timestamp to make it the "current" one
                 await tx.run(`
                     CALL apoc.trigger.add("updateSlugIdRelation", "
-                        UNWIND apoc.trigger.propertiesByKey($assignedNodeProperties, 'slugId') AS prop
+                        // $assignedNodeProperties is map of {key: [list of {key,old,new,node}]}
+                        UNWIND $assignedNodeProperties.slugId AS prop
                         WITH prop.node as n, prop.old as oldSlugId
                         WHERE n:VNode AND n.slugId IS NOT NULL AND n.slugId <> oldSlugId
                         MERGE (s:SlugId {slugId: n.slugId})-[:IDENTIFIES]->(n)


### PR DESCRIPTION
[APOC Core is included with Neo4j](https://neo4j.com/labs/apoc/4.3/installation/) and Neo4j will spin up faster if we use the included distribution of APOC Core instead of telling the docker container to download APOC Full on startup.

I just had to remove the use of `apoc.trigger.propertiesByKey(...)` which is part of APOC Full, not APOC Core.