### PR TITLE
Allow VNodes to define list-typed properties

### DIFF
--- a/vertex/layer4/action.ts
+++ b/vertex/layer4/action.ts
@@ -116,9 +116,8 @@ export class Action extends VNodeType {
         tookMs: Field.Int,
         // What this action did, in English, with Node IDs inline like `Created ${Person.withId(newPersonVNID)}`
         description: Field.String,
-        // Did this action (permanently) delete any nodes? (Set by the trackActionChanges trigger), used by the
-        // getActionChanges() function. If this is > 0, this action cannot be undone/reversed.
-        deletedNodesCount: Field.Int,
+        // This contains the VNIDs of any VNodes that were deleted by this action.
+        deletedNodeIds: Field.List(Field.VNID),
     };
     static async validate(_dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
         // No specific validation

--- a/vertex/lib/types/field.test.ts
+++ b/vertex/lib/types/field.test.ts
@@ -494,6 +494,45 @@ group(import.meta, () => {
             });
         });
 
+        group("List", () => {
+
+            test("Basic field", () => {
+                const fieldDeclaration = Field.List(Field.String);
+                assertEquals(fieldDeclaration.type, FieldType.List);
+                assertEquals(fieldDeclaration.nullable, false);
+    
+                const value1 = validateValue(fieldDeclaration, ["s1", "s2"]);
+                checkType<AssertEqual<typeof value1, string[]>>();
+                assertEquals(value1, ["s1", "s2"]);  // Ensure that validation has preserved the value.
+                // These should all be valid:
+                const check = (str: string[]) => assertEquals(validateValue(fieldDeclaration, str), str);
+                check([]);
+                check(["one"]);
+                check(["one", "two"]);
+
+                // These should not be valid:
+                assertThrows(() => { validateValue(fieldDeclaration, "a string, not an array"); });
+                assertThrows(() => { validateValue(fieldDeclaration, ["next value is not a string =>", 3]); });
+                assertThrows(() => { validateValue(fieldDeclaration, null); });
+            });
+    
+            test("NullOr.", () => {
+                const fieldDeclaration = Field.NullOr.List(Field.Int);
+                assertEquals(fieldDeclaration.type, FieldType.List);
+                assertEquals(fieldDeclaration.nullable, true);
+    
+                const value1 = validateValue(fieldDeclaration, [1, 2, 3]);
+                checkType<AssertEqual<typeof value1, number[]|null>>();
+                const value2 = validateValue(fieldDeclaration, null);
+                assertStrictEquals(value2, null);
+                assertThrows(() => { validateValue(fieldDeclaration, ["not a number"]); });
+                assertThrows(() => { validateValue(fieldDeclaration, {}); });
+                assertThrows(() => { validateValue(fieldDeclaration, undefined); });
+            });
+
+            // TODO: implement support for .Check() on Field.List when used as a property
+        });
+
         group("validatePropSchema", () => {
             const buildingSchema: PropSchema = {
                 name: Field.String,
@@ -537,12 +576,11 @@ group(import.meta, () => {
                 fieldDate: Field.Date,
                 fieldDT: Field.DateTime,
                 fieldAP: Field.AnyPrimitive,
+                fieldList: Field.List(Field.String),
                 // @ts-expect-error a Record is not allowed in a property schema
                 fieldRecord: Field.Record({key: Field.String}),
                 // @ts-expect-error a Map is not allowed in a property schema
                 fieldMap: Field.Map(Field.String),
-                // @ts-expect-error a List is not allowed in a property schema
-                fieldList: Field.List(Field.String),
                 // @ts-expect-error an AnyGeneric is not allowed in a property schema
                 fieldAnyGeneric: Field.AnyGeneric,
                 // @ts-expect-error a Node is not allowed in a property schema

--- a/vertex/lib/types/validator.ts
+++ b/vertex/lib/types/validator.ts
@@ -69,6 +69,14 @@ export const validateFloat: Validator<number> = (value) => {
     return value;
 };
 
+/** A list validator */
+export const validateList: Validator<any[]> = (value) => {
+    if (!Array.isArray(value)) {
+        throw new Error("Not a list");
+    }
+    return value;
+};
+
 /** An string validator */
 export const validateString: Validator<string> = (value) => {
     if (typeof value !== "string") {


### PR DESCRIPTION
Neo4j allows nodes to have property values that are lists of primitive values. Now Vertex Framework does too.