### PR TITLE
JSON object fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const firstMovieTitle = await graph.read(async tx => {
     const result = await tx.queryOne(C`
         MATCH (p:${Person} {id: ${personId}})
         MATCH (p)-[:${Person.rel.ACTED_IN}]->(movie:${Movie})
-    `.RETURN({movie: Movie}));
+    `.RETURN({movie: Field.VNode(Movie)}));
 
     return result.movie.title;
 });

--- a/vertex/layer2/cypher-return-shape.test.ts
+++ b/vertex/layer2/cypher-return-shape.test.ts
@@ -66,6 +66,12 @@ group(import.meta, () => {
         assertEquals(results, [{value: hello}]);
         assertEquals(typeof results[0].value, "string");
     });
+    test("basic test - a typed record with a JsonObjString field.", async () => {
+        const shape = ResponseSchema({value: Field.JsonObjString});
+        const results = await runAndConvert(`RETURN "{\\"foo\\": 123, \\"bar\\": [true, false]}" as value`, {}, shape);
+        assertEquals(results, [{value: {foo: 123, bar: [true, false]}}]);
+        assertEquals(typeof results[0].value, "object");
+    });
     test("basic test - a typed record with a Boolean field.", async () => {
         const shape = ResponseSchema({value: Field.Boolean});
         const results = await runAndConvert(`RETURN true as value`, {}, shape);

--- a/vertex/layer2/cypher-return-shape.ts
+++ b/vertex/layer2/cypher-return-shape.ts
@@ -44,6 +44,9 @@ export function convertNeo4jFieldValue<FD extends TypedField>(fieldName: string,
         case FieldType.Slug: {
             return fieldValue;
         }
+        case FieldType.JsonObjString: {
+            return JSON.parse(fieldValue);
+        }
         ////////////////////////////////////////////////
         // Composite field types
         case FieldType.Record: {

--- a/vertex/lib/types/field.test.ts
+++ b/vertex/lib/types/field.test.ts
@@ -19,6 +19,7 @@ import {
     Path,
     PrimitiveValue,
     GenericValue,
+    JsonObject,
 } from "./field.ts";
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -342,6 +343,44 @@ group(import.meta, () => {
             });
         });
 
+        group("JSON Object String", () => {
+
+            test("Basic field", () => {
+                const fieldDeclaration = Field.JsonObjString;
+                assertEquals(fieldDeclaration.type, FieldType.JsonObjString);
+                assertEquals(fieldDeclaration.nullable, false);
+    
+                const value1 = validateValue(fieldDeclaration, {foo: "bar"});
+                checkType<AssertEqual<typeof value1, JsonObject>>();
+                assertEquals(typeof value1, "object");
+                assertEquals(value1, {foo: "bar"});  // Ensure that validation has preserved the value.
+                // These should all be valid:
+                const check = (value: Record<string, unknown>) => assertEquals(validateValue(fieldDeclaration, value), value);
+                check({});
+                check({a: 1, b: 2});
+                check({c: null, d: "foo", e: {f: null, g: [1, "a"]}});
+
+                assertThrows(() => { validateValue(fieldDeclaration, [1, 2, 3]); });
+                assertThrows(() => { validateValue(fieldDeclaration, "string"); });
+                assertThrows(() => { validateValue(fieldDeclaration, null); });
+                assertThrows(() => { validateValue(fieldDeclaration, undefined); });
+            });
+    
+            test("NullOr.", () => {
+                const fieldDeclaration = Field.NullOr.JsonObjString;
+                assertEquals(fieldDeclaration.type, FieldType.JsonObjString);
+                assertEquals(fieldDeclaration.nullable, true);
+    
+                const value1 = validateValue(fieldDeclaration, {foo: "bar"});
+                checkType<AssertEqual<typeof value1, JsonObject|null>>();
+                const value2 = validateValue(fieldDeclaration, null);
+                assertStrictEquals(value2, null);
+                assertThrows(() => { validateValue(fieldDeclaration, [1, 2, 3]); });
+                assertThrows(() => { validateValue(fieldDeclaration, "string"); });
+                assertThrows(() => { validateValue(fieldDeclaration, undefined); });
+            });
+        });
+
         group("Boolean", () => {
 
             test("Basic field", () => {
@@ -578,6 +617,7 @@ group(import.meta, () => {
                 fieldFloat: Field.Float,
                 fieldStr: Field.String,
                 fieldSlug: Field.Slug,
+                fieldJsonObjString: Field.JsonObjString,
                 fieldBool: Field.Boolean,
                 fieldDate: Field.Date,
                 fieldDT: Field.DateTime,

--- a/vertex/lib/types/validator.ts
+++ b/vertex/lib/types/validator.ts
@@ -5,6 +5,7 @@
  * These are for internal use within Vertex Framework only, and aren't exported as part of the framework code.
  */
 import { Neo4j } from "../../deps.ts";
+import type { JsonObject } from "./field.ts";
 import { VDate } from "./vdate.ts";
 import { isVNID, VNID } from "./vnid.ts";
 
@@ -147,6 +148,14 @@ export const validateSlug: Validator<string> = (_value) => {
     }
     return value;
 }
+
+/** Validate that the value is an object (map) that has been encoded as a JSON string. */
+export const validateJsonObjString: Validator<JsonObject> = (value) => {
+    if (typeof value !== "object" || Array.isArray(value) || value === null) {
+        throw new Error("JSON Object typed field is a JSON encoded string but is not an object (map).")
+    }
+    return value as JsonObject;
+};
 
 const emailTester = /^[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
 


### PR DESCRIPTION
This allows VNode fields to be "JSON Object Strings", which is any JavaScript object `{ key: "value" }` serialized as a JSON string.

When reading from Neo4j, the field is transparently unserialized back to a JavaScript object. When saving, the field is validated to ensure it is valid JSON and is an object (not an array, a string, undefined, null, etc.)