### PR TITLE
feat: Implement query profiling (requires no changes to query code)

### DIFF
--- a/vertex/layer4/action-runner.ts
+++ b/vertex/layer4/action-runner.ts
@@ -14,7 +14,7 @@ import { baseValidateVNode } from "./validation.ts";
  */
 export async function runAction<T extends ActionRequest>(graph: VertexCore, actionRequest: T, userId?: VNID): Promise<ActionResult<T>> {
     const actionId = VNID();
-    const startTime = new Date();
+    const startTime = performance.now();
     const {type, parameters} = actionRequest;
     const ActionDefinition = getActionDefinition(type);
     if (ActionDefinition === undefined) {
@@ -24,7 +24,7 @@ export async function runAction<T extends ActionRequest>(graph: VertexCore, acti
         userId = SYSTEM_VNID;
     }
 
-    const [result, tookMs, description] = await graph._restrictedWrite(async (tx) => {
+    const [result, applyTookMs, validationTookMs, description] = await graph._restrictedWrite(async (tx) => {
 
         // First, apply the action:
         const modifiedNodeIds = new Set<VNID>();
@@ -56,6 +56,7 @@ export async function runAction<T extends ActionRequest>(graph: VertexCore, acti
             throw new Error(`${type} action failed during apply() method (${err.message}).`, {cause: err});
         }
 
+        const validationStartTime = performance.now();
         if (modifiedNodeIds.size > 0) {
             // Mark the Action as having :MODIFIED any affects nodes, and also retrieve the current version of them.
             // (If a node was deleted, this will ignore it.)
@@ -125,22 +126,24 @@ export async function runAction<T extends ActionRequest>(graph: VertexCore, acti
         }
 
         // Then record the entry into the global action log, since the action succeeded.
-        const tookMs = (new Date()).getTime() - startTime.getTime();
+        const applyTookMs = validationStartTime - startTime;
+        const validationTookMs = performance.now() - validationStartTime;
 
         await tx.queryOne(C`
             MATCH (a:${Action} {id: ${actionId}})
-            SET a.tookMs = ${tookMs}
+            SET a.tookMs = ${applyTookMs + validationTookMs}
             SET a.description = ${description}
             RETURN null
         `);
 
-        return [resultData, tookMs, description];
+        return [resultData, applyTookMs, validationTookMs, description];
     });
 
-    // Calculate how long it took to commit the transaction too
-    const commitMs = (new Date()).getTime() - startTime.getTime() - tookMs;
+    // Calculate how long it took to commit the transaction too (mostly the time to run our triggers)
+    const commitMs = performance.now() - startTime - applyTookMs - validationTookMs;
 
-    log.info(`${description} (${type} took ${tookMs} ms + ${commitMs} ms)`); // TODO: a way for actions to describe themselves verbosely
+    const totalTime = performance.now() - startTime;
+    log.info(`${description} (${type} took ${totalTime}ms: ${applyTookMs}ms action + ${validationTookMs}ms validation + ${commitMs}ms commit)`);
 
     result.actionId = actionId;
     result.actionDescription = description;


### PR DESCRIPTION
This allows developers and test code to turn on profiling, run some code, then see how many `dbHits` were made to Neo4j while profiling was on.

It also includes optional query logging.