### PR TITLE
perf: preload data for validation in a single query

### DIFF
--- a/vertex/index.ts
+++ b/vertex/index.ts
@@ -30,16 +30,14 @@ export {
     validateValue,
     validatePropSchema,
     FieldValidationError,
-} from "./lib/types/field.ts";
-export type {
-    TypedField,
-    ResponseFieldType,
-    GetDataType,
-    GetDataShape,
+    type TypedField,
+    type ResponseFieldType,
+    type GetDataType,
+    type GetDataShape,
     // Neo4j types:
-    Node,
-    Relationship,
-    Path,
+    type Node,
+    type Relationship,
+    type Path,
 } from "./lib/types/field.ts";
 
 //// Layer 1 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -65,6 +63,7 @@ export {
     ValidationError,
     //isBaseVNodeType - internal use only
     getRelationshipType,
+    type RawRelationships,
 } from "./layer2/vnode-base.ts";
 export type {
     RawVNode,
@@ -103,9 +102,7 @@ export type {
 
 export {
     DerivedProperty,
-} from "./layer3/derived-props.ts";
-export type {
-    DerivedPropertyFactory,
+    type DerivedPropertyFactory,
 } from "./layer3/derived-props.ts";
 
 export {
@@ -126,12 +123,10 @@ export {
 
 export {
     Action,
+    type ActionRequest,
+    type ActionDefinition,
+    type ActionResult,
     defineAction,
-} from "./layer4/action.ts";
-export type {
-    ActionRequest,
-    ActionDefinition,
-    ActionResult,
 } from "./layer4/action.ts";
 
 export {

--- a/vertex/layer4/action.ts
+++ b/vertex/layer4/action.ts
@@ -5,7 +5,7 @@
  * transform it to another state.
  */
 import { VNID } from "../lib/types/vnid.ts";
-import { BaseVNodeType, RawVNode } from "../layer2/vnode-base.ts";
+import { BaseVNodeType } from "../layer2/vnode-base.ts";
 import { WrappedTransaction } from "../transaction.ts";
 import { C } from "../layer2/cypher-sugar.ts";
 import { VNodeType } from "../layer3/vnode.ts";
@@ -118,7 +118,7 @@ export class Action extends VNodeType {
         // This contains the VNIDs of any VNodes that were deleted by this action.
         deletedNodeIds: Field.NullOr.List(Field.VNID),
     };
-    static async validate(_dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
+    static async validate(): Promise<void> {
         // No specific validation
     }
     static readonly rel = this.hasRelationshipsFromThisTo({


### PR DESCRIPTION
This makes validation much more efficient: simple validation is unchanged, but validation which requires reading from the active database transaction can now be done with a single query for all VNodes of a given type that were changed in a transaction. This is _much_ faster than doing many small queries, 1+ for each VNode of that type that was changed.