### PR TITLE
Improvements to validation - better typing, pass VNID of rel targets

### DIFF
--- a/vertex/layer2/vnode-base.ts
+++ b/vertex/layer2/vnode-base.ts
@@ -156,7 +156,7 @@ export interface RawRelationships {
     relType: string;
     relProps: Record<string, unknown>;
     targetLabels: string[];
-    targetId: number;
+    targetId: VNID;
 }
 
 export interface BaseVNodeType {

--- a/vertex/layer4/validation.ts
+++ b/vertex/layer4/validation.ts
@@ -1,20 +1,9 @@
 import { convertNeo4jFieldValue } from "../layer2/cypher-return-shape.ts";
 import { C } from "../layer2/cypher-sugar.ts";
-import { Cardinality, emptyObj, PropSchemaWithId, RawVNode, ValidationError } from "../layer2/vnode-base.ts";
+import { Cardinality, emptyObj, PropSchemaWithId, RawRelationships, RawVNode, ValidationError } from "../layer2/vnode-base.ts";
 import { VNodeType } from "../layer3/vnode.ts";
 import { validatePropSchema } from "../lib/types/field.ts";
 import { WrappedTransaction } from "../transaction.ts";
-
-
-/**
- * Data about all relationships from a given VNode, used to validate its relationships
- */
-interface RelationshipData {
-    relType: string,
-    relProps: Record<string, unknown>,
-    targetLabels: string[],
-    targetId: number,
-}
 
 
 /**
@@ -27,7 +16,7 @@ interface RelationshipData {
  * @param dbObject 
  * @param tx 
  */
-export async function baseValidateVNode(vnt: VNodeType, dbObject: RawVNode<VNodeType>, relationships: RelationshipData[], tx: WrappedTransaction): Promise<void> {
+export async function baseValidateVNode(vnt: VNodeType, dbObject: RawVNode<VNodeType>, relationships: RawRelationships[], tx: WrappedTransaction): Promise<void> {
 
     // Validate slugId prefix
     if (vnt.slugIdPrefix !== "") {


### PR DESCRIPTION
In Neolace we have a use case where the validation is much more efficient if we pass the VNIDs of the relationship targets, not the Neo4j node IDs. (It saves an extra query to look up the VNID of the associated `Site` node).

This also improves some typing of exceptions in the validation phase.