### PR TITLE
chore: Bump Neo4j JavaScript Driver to 5.3.0 - fixes clearTimeout bug

### DIFF
--- a/vertex/deps.ts
+++ b/vertex/deps.ts
@@ -1,4 +1,4 @@
-import neo4j, * as Neo4j from "https://raw.githubusercontent.com/neo4j/neo4j-javascript-driver/5.1.0/packages/neo4j-driver-deno/lib/mod.ts";
+import neo4j, * as Neo4j from "https://raw.githubusercontent.com/neo4j/neo4j-javascript-driver/5.3.0/packages/neo4j-driver-deno/lib/mod.ts";
 // For local development:
 // import neo4j, * as Neo4j from "../../deno-neo4j-lite-client/mod.ts";
 export {

--- a/vertex/lib/types/validator.ts
+++ b/vertex/lib/types/validator.ts
@@ -139,7 +139,8 @@ const slugRegex = /^[-\p{Alphabetic}\p{Mark}\p{Decimal_Number}\p{Join_Control}]+
 
 /**
  * Validate that a string value is a slug. Can contain letters from any language, but not spaces or punctuation other
- * than hyphen (hyphen is allowed, but underscore is not as underscore is less visible when text is underlined).
+ * than hyphen (hyphen is allowed, but underscore is not as underscore is less visible when text is underlined) and it
+ * is essential that there is no overlap between slugs and VNIDs (VNIDs start with an underscore).
  */
 export const validateSlug: Validator<string> = (_value) => {
     const value = validateString(_value);


### PR DESCRIPTION
See https://github.com/neo4j/neo4j-javascript-driver/wiki/5.0-changelog - in particular, we want https://github.com/neo4j/neo4j-javascript-driver/pull/1016