### PR TITLE
fix: work around the validateActionModified trigger being slow on neo4j enterprise

### DIFF
--- a/vertex/layer4/schema.ts
+++ b/vertex/layer4/schema.ts
@@ -81,6 +81,8 @@ export const migrations: Readonly<{[id: string]: Migration}> = Object.freeze({
                 await tx.run(`
                     CALL apoc.trigger.add("validateActionModified", "
 
+                        CYPHER runtime=slotted // avoid huge slowdown with pipelined runtime on Neo4j Enterprise 5.2.0
+
                         // Start with a MATCH so this trigger only runs when there is an action in the transaction
                         MATCH (action:Action:VNode)
                             WHERE id(action) IN [cn IN $createdNodes WHERE cn:Action | id(cn)]


### PR DESCRIPTION
It took me all day to figure out why our data was loading so much more slowly in the cloud than on my local machine.
First I thought it was the hosting setup (k8s vs. local docker), then I thought it was Enterprise vs. Community (which it was, technically), then I _finally_ narrowed it down to the `validateActionModified` trigger.

It appears that when the `validateActionModified` trigger runs with the enterprise "pipelined" runtime, it slows things down by at least a factor of 2. A command to ingest data went from taking 30s to 67s or more.

Unfortunately it's hard to debug the issue any further as I can't run the query outside of the trigger context to see how the profile might be different.