### PR TITLE
Improve logging

### DIFF
--- a/vertex/deps.ts
+++ b/vertex/deps.ts
@@ -7,3 +7,4 @@ export {
 }
 
 export * as stdLog from "https://deno.land/std@0.175.0/log/mod.ts"
+export { format as formatDuration } from "https://deno.land/std@0.175.0/fmt/duration.ts";

--- a/vertex/layer2/vnode-ref.test.ts
+++ b/vertex/layer2/vnode-ref.test.ts
@@ -41,6 +41,7 @@ group(import.meta, () => {
     });
 
     test("a forward reference's relationships can be accessed before the forward reference is resolved", () => {
+        // deno-lint-ignore no-unused-vars
         const test = OtherVNTRef.rel.SELF_RELATIONSHIP;
         // And typescript sees it as a VNode Relationship declaration:
         assertType<Has<typeof test["to"], Array<unknown>>>(true);

--- a/vertex/lib/log.ts
+++ b/vertex/lib/log.ts
@@ -3,8 +3,6 @@
  */
 import { stdLog, Neo4j } from "../deps.ts";
 
-export const log = stdLog;
-
 /** Version of JSON.stringify that supports bigint and date types. Useful for debugging. */
 export function stringify(data: unknown): string {
     return JSON.stringify(data, (_key, value) =>
@@ -13,3 +11,28 @@ export function stringify(data: unknown): string {
         value
     );
 }
+
+// Fix the awkward Deno std log API by wrapping it.
+// This will ensure all logs use the "vertex-framework" logger so that applications can have fine control over our logs.
+// This will also change the log functions so that they'll convert any arguments to nicely formatted strings.
+const moduleName = "vertex-framework";
+const getLogger = stdLog.getLogger;
+const fmtObj = typeof Deno?.inspect === "function" ? Deno.inspect : stringify;
+const fmt = (msg: unknown) => typeof msg === "string" ? msg : fmtObj(msg);
+export const log = {
+    warning(...args: unknown[]) {
+        getLogger(moduleName).warning(() => args.map((a) => fmt(a)).join(" "));
+    },
+    debug(...args: unknown[]) {
+        getLogger(moduleName).debug(() => args.map((a) => fmt(a)).join(" "));
+    },
+    info(...args: unknown[]) {
+        getLogger(moduleName).info(() => args.map((a) => fmt(a)).join(" "));
+    },
+    error(...args: unknown[]) {
+        getLogger(moduleName).error(() => args.map((a) => fmt(a)).join(" "));
+    },
+    critical(...args: unknown[]) {
+        getLogger(moduleName).critical(() => args.map((a) => fmt(a)).join(" "));
+    },
+};

--- a/vertex/test-project/index.ts
+++ b/vertex/test-project/index.ts
@@ -4,7 +4,6 @@ export const testGraph = new Vertex({
     neo4jUrl: Deno.env.get("NEO4J_URL") ?? "bolt://localhost:7777",
     neo4jUser: "neo4j",
     neo4jPassword: "vertex",
-    debugLogging: true,
     extraMigrations: {
         // Make the 'slugId' field act as a unique key for the VNode types in the test project:
         slugIdUnique: {

--- a/vertex/transaction.ts
+++ b/vertex/transaction.ts
@@ -8,7 +8,7 @@ import { query, queryOne } from "./layer2/query.ts";
 import { OneRelationshipSpec, RelationshipSpec, updateToManyRelationship, updateToOneRelationship } from "./layer4/action-helpers.ts";
 import { pull, pullOne, PullNoTx, PullOneNoTx } from "./layer3/pull.ts";
 import { VNodeType } from "./layer3/vnode.ts";
-import { log } from "./lib/log.ts";
+import { log, stringify } from "./lib/log.ts";
 
 /** A data structure to keep track of the dbHits (performance measure) for all queries run */
 export interface ProfileStats {
@@ -19,6 +19,7 @@ export interface ProfileStats {
 /** A Neo4j Transaction with some Vertex Framework convenience methods */
 export class WrappedTransaction {
     #tx: Neo4j.ManagedTransaction;
+    statementProfile?: ProfileStats;
 
     public constructor(plainTx: Neo4j.ManagedTransaction, public readonly profile?: ProfileStats) {
         this.#tx = plainTx;
@@ -32,22 +33,47 @@ export class WrappedTransaction {
      */
     public async run(query: string, parameters?: { [key: string]: any }): Promise<Neo4j.QueryResult> {
         const origQuery = query;
-        if (this.profile) {
+        const profile = this.statementProfile ?? this.profile;
+        if (profile) {
             // We want to measure dbHits stats for all queries exectuted:
             query = `PROFILE ` + query;
         }
         const result = await this.#tx.run(query, parameters ? fixParameterTypes(parameters) : undefined);
-        if (this.profile && result.summary.profile) {
+        if (profile && result.summary.profile) {
             let dbHits = 0;
             const addHits = (profileObj: Neo4j.ProfiledPlan) => { dbHits += profileObj.dbHits; profileObj.children.forEach(addHits); }
             addHits(result.summary.profile);
-            this.profile.dbHits += dbHits;
-            if (this.profile.queryLogMode) {
-                const queryFormatted = this.profile.queryLogMode === "compact" ? origQuery.trim().replaceAll(/\s+/g, " ").substring(0, 100).padEnd(100, " ") : origQuery;
+            profile.dbHits += dbHits;
+            if (profile.queryLogMode) {
+                const queryFormatted = profile.queryLogMode === "compact" ? origQuery.trim().replaceAll(/\s+/g, " ").substring(0, 100).padEnd(100, " ") : origQuery;
                 log.info(`Neo4j query: ${queryFormatted} (${dbHits} dbHits)`);
+                if (profile.queryLogMode === "full") {
+                    // Try to format the parameters in the same way as Neo4j so one can copy-paste this into a Cypher shell:
+                    log.debug(stringify(result.summary.query.parameters).replaceAll(/"([\w]+)":/g, "$1:"));
+                    const root = result.summary.profile;
+                    const print = (node: typeof root, depth: number) => {
+                        log.debug("  ".repeat(depth) + "*" + node.operatorType + "(" + node.dbHits + " dbHits, " + node.rows + " rows) " + (node.arguments["Details"] ?? ""));
+                        for (const child of node.children) {
+                            print(child, depth + 1);
+                        }
+                    }
+                    print(root, 0);
+                }
+            }
+            if (this.statementProfile && this.profile) {
+                // Add the dbHits from the per-statement profile to the transaction-level profile:
+                this.profile.dbHits += this.statementProfile.dbHits;
             }
         }
         return result;
+    }
+
+    public startProfile(queryLogMode?: "compact"|"full") {
+        if (this.statementProfile) throw new Error("per-statement profile is already on");
+        this.statementProfile = {dbHits: 0, queryLogMode};
+    }
+    public finishProfile() {
+        this.statementProfile = undefined;
     }
 
     public query<CQ extends CypherQuery>(cypherQuery: CQ): Promise<QueryResponse<CQ>[]> {

--- a/vertex/vertex.ts
+++ b/vertex/vertex.ts
@@ -19,7 +19,6 @@ export interface InitArgs {
     neo4jUrl: string; // e.g. "bolt://localhost:7687"
     neo4jUser: string; // e.g. "neo4j",
     neo4jPassword: string;
-    debugLogging?: boolean;
     extraMigrations: {[name: string]: Migration};
 }
 


### PR DESCRIPTION
* Use a Deno logger named `vertex-framework` so applications can control log format, output, and verbosity
* Implement per-statement debugging - within a transaction you can now turn profiling on, run one or more statements, then collect the profile result.
* When profiling queries, print the exact time that each statement took as well as the 