### PR TITLE
feat: profiling can report the number of distinct queries

### DIFF
--- a/vertex/transaction.ts
+++ b/vertex/transaction.ts
@@ -13,6 +13,7 @@ import { log, stringify } from "./lib/log.ts";
 /** A data structure to keep track of the dbHits (performance measure) for all queries run */
 export interface ProfileStats {
     dbHits: number;
+    numQueries: number;
     queryLogMode?: "compact"|"full";
 }
 
@@ -67,9 +68,11 @@ export class WrappedTransaction {
                     print(root, 0);
                 }
             }
+            profile.numQueries++;
             if (this.statementProfile && this.profile) {
                 // Add the dbHits from the per-statement profile to the transaction-level profile:
                 this.profile.dbHits += this.statementProfile.dbHits;
+                this.profile.numQueries++;
             }
         }
         return result;
@@ -77,7 +80,7 @@ export class WrappedTransaction {
 
     public startProfile(queryLogMode?: "compact"|"full") {
         if (this.statementProfile) throw new Error("per-statement profile is already on");
-        this.statementProfile = {dbHits: 0, queryLogMode};
+        this.statementProfile = {dbHits: 0, numQueries: 0, queryLogMode};
     }
     public finishProfile() {
         this.statementProfile = undefined;

--- a/vertex/vertex.ts
+++ b/vertex/vertex.ts
@@ -107,7 +107,7 @@ export class Vertex implements VertexCore {
      * help debug issues with queries.
      */
     public startProfile(queryLogMode?: "compact"|"full") {
-        this.activeProfile.push({dbHits: 0, queryLogMode});
+        this.activeProfile.push({dbHits: 0, numQueries: 0, queryLogMode});
     }
 
     /**
@@ -122,6 +122,7 @@ export class Vertex implements VertexCore {
         if (nextProfile) {
             // Add the hits from this inner profile to any outer profile that's still running. (Support nesting.)
             nextProfile.dbHits += result.dbHits;
+            nextProfile.numQueries += result.numQueries;
         }
         return result;
     }


### PR DESCRIPTION
In addition to dbHits, a profile can now be used to count how many distinct queries it took to compute some result. Usually, fewer queries means more efficient.